### PR TITLE
Upgrade TinyMCE and Angular in Settings [stage-2]

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,11 +18,11 @@
     "test"
   ],
   "devDependencies": {
-    "angular-mocks": "~1.3.0",
+    "angular-mocks": "~1.4.x",
     "web-component-tester": "*"
   },
   "dependencies": {
-    "angular": "~1.3.0",
+    "angular": "~1.4.0",
     "angular-bootstrap": "~0.11.1",
     "auto-scroll": "https://github.com/Rise-Vision/auto-scroll.git#1.1.0",
     "gsap": "~1.18.2",
@@ -32,12 +32,12 @@
     "widget-common": "https://github.com/Rise-Vision/widget-common.git#3.4.4",
     "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#1.2.12",
     "widget-settings-ui-core": "https://github.com/Rise-Vision/widget-settings-ui-core.git#0.4.3",
-    "tinymce": "4.5.2"
+    "tinymce": "4.5.7"
   },
   "resolutions": {
-    "angular": "~1.3.0",
+    "angular": "~1.4.0",
     "angular-bootstrap": "^0.13.0",
-    "angular-mocks": "~1.3.0",
+    "angular-mocks": "~1.4.x",
     "angular-sanitize": "~1.3.0",
     "angular-ui-router": "0.2.15",
     "gsap": "~1.13.2",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -35,10 +35,10 @@
       "./src/components/gsap/src/minified/plugins/CSSPlugin.min.js",
       "./src/components/gsap/src/minified/utils/Draggable.min.js",
       "./src/components/gsap/src/minified/plugins/ScrollToPlugin.min.js",
-      "./src/components/tinymce-dist/plugins/**/*",
-      "./src/components/tinymce-dist/skins/**/*",
-      "./src/components/tinymce-dist/themes/**/*",
-      "./src/components/tinymce-dist/tinymce*.js",
+      "./src/components/tinymce/plugins/**/*",
+      "./src/components/tinymce/skins/**/*",
+      "./src/components/tinymce/themes/**/*",
+      "./src/components/tinymce/tinymce*.js",
       "./src/components/angular/angular*.js",
       "./src/components/angular/*.gzip",
       "./src/components/angular/*.map",
@@ -139,8 +139,7 @@
   // ***** e2e Testing ***** //
   gulp.task("html:e2e:settings", factory.htmlE2E({
     files: "./src/settings.html",
-    e2eFontLoader: "../node_modules/widget-tester/mocks/web-font-loader-mock.js",
-    e2etinymce: "components/tinymce-dist/tinymce.min.js"
+    e2eFontLoader: "../node_modules/widget-tester/mocks/web-font-loader-mock.js"
   }));
 
   gulp.task("e2e:server:settings", ["config", "html:e2e:settings"], factory.testServer());

--- a/src/settings.html
+++ b/src/settings.html
@@ -32,7 +32,7 @@
     })(window,document,'FS','script','user');
   </script>
 
-  <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.20/angular.min.js"></script>
+  <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.4.14/angular.min.js"></script>
   <!-- if AngularJS fails to load fallback to a local version -->
   <script>window.angular || document.write(unescape("%3Cscript src='js/vendor/angular/angular.min.js' type='text/javascript'%3E%3C/script%3E"));
   </script>


### PR DESCRIPTION
- Angular upgraded to `1.4.14`
- TinyMCE upgraded to `4.5.7`
- Stop targeting tinymce-dist for distributing vendor files