### PR TITLE
resizes tooltip popup to stay within modal [stage-6]

### DIFF
--- a/src/settings.html
+++ b/src/settings.html
@@ -13,6 +13,13 @@
     body, html {
       background: transparent;
     }
+
+    /*reduces size of tooltip for small desktop screens and above*/
+    @media (min-width:992px) {
+      .popover {
+        max-width: 120px;
+      }
+    }
   </style>
 
   <!--FullStory-->


### PR DESCRIPTION
@Rise-Vision/content please review - this uses the same CSS fix to resolve the tooltip placement issue. Thanks!