### PR TITLE
Upgrade gulp-source maps but remove applying it for settings.js

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Description
+Include a summary of the change. If this is fixing a defect, ensure to link to the issue this is fixing.
+
+## Motivation and Context
+Why is this change required? What problem does it solve?
+
+## How Has This Been Tested?
+Describe in detail how you tested your changes. Include details of your testing environment and link(s) for reviewers to validate.
+
+## Release Plan:
+- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
+- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed
+
+#### Release Checklist Items Skipped?
+If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -83,7 +83,7 @@
         // Minify for production.
         usemin({
           css: [sourcemaps.init(), minifyCSS(), sourcemaps.write()],
-          js: [sourcemaps.init( {largeFile: true} ), uglify(), sourcemaps.write()]
+          js: [uglify()]
         }),
         // Don't minify for staging.
         usemin({})

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,16 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@gulp-sourcemaps/map-sources": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/map-sources/-/map-sources-1.0.0.tgz",
-      "integrity": "sha1-iQrnxdjId/bThIYCFazp1+yUW9o=",
-      "dev": true,
-      "requires": {
-        "normalize-path": "^2.0.1",
-        "through2": "^2.0.3"
-      }
-    },
     "@sinonjs/commons": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.6.0.tgz",
@@ -4455,20 +4445,19 @@
       "dev": true
     },
     "gulp-sourcemaps": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.12.1.tgz",
-      "integrity": "sha1-tDfR89mAzyboEYSCNxjOFa5ll7Y=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-2.4.1.tgz",
+      "integrity": "sha1-j2XcXA0Hsv1ciLxg7H8T5WcWv3Q=",
       "dev": true,
       "requires": {
-        "@gulp-sourcemaps/map-sources": "1.X",
         "acorn": "4.X",
         "convert-source-map": "1.X",
         "css": "2.X",
         "debug-fabulous": "0.0.X",
         "detect-newline": "2.X",
         "graceful-fs": "4.X",
-        "source-map": "~0.6.0",
-        "strip-bom": "2.X",
+        "source-map": "0.X",
+        "strip-bom": "3.X",
         "through2": "2.X",
         "vinyl": "1.X"
       },
@@ -4479,20 +4468,11 @@
           "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
           "dev": true
         },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
         "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "^0.2.0"
-          }
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
         },
         "vinyl": {
           "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "gulp-jshint": "~1.5.5",
     "gulp-minify-css": "0.3.4",
     "gulp-rename": "~1.2.0",
-    "gulp-sourcemaps": "^1.2.2",
+    "gulp-sourcemaps": "2.4.1",
     "gulp-uglify": "^0.3.1",
     "gulp-usemin": "0.3.7",
     "gulp-util": "~2.2.17",


### PR DESCRIPTION
## Description
Use latest version of `gulp-sourcemaps`.

Remove generating sourcemaps for `settings.min.js` 

## Motivation and Context
The `largefile` gulp-sourcemaps flag is having no impact on reducing the size of the `settings.min.js` file. The base64 mapping is still applied and is bloating the size of the file. 

Given this is a legacy product no longer maintained regularly, sourcemaps are not essential. 

## How Has This Been Tested?
Tested locally and staged widget

https://apps.risevision.com/editor/workspace/0f483dc6-56cd-4693-8142-bca12d3ba4d4?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why