### PR TITLE
Increase timeout of WebFontLoader from 2 to 5 seconds

### DIFF
--- a/src/widget/text.js
+++ b/src/widget/text.js
@@ -26,12 +26,16 @@ RiseVision.Text = (function(gadgets, WebFont) {
         google: {
           families: fonts
         },
-        timeout: 2000,
+        timeout: 5000,
         active: function() {
           complete();
         },
         inactive: function() {
-          console.warn("No google fonts were loaded");
+          _logEvent({
+            "event": "error",
+            "event_details": "Google fonts were not loaded",
+            "error_details": JSON.stringify( { googleFonts: fonts } )
+          });
           complete();
         },
         fontinactive: function(familyName) {


### PR DESCRIPTION
## Description
Increasing the `timeout` value of 2 seconds to 5 seconds for the instance of WebFontLoader library (used to facilitate the loading and importing of Google fonts)

## Motivation and Context
An initial approach to reduce and potentially eliminate the problem as defined in issue #141 

## How Has This Been Tested?
Validated widget is working as expected with staged version - https://apps.risevision.com/editor/workspace/6ec8d16f-1191-4d6e-9f50-f224dcd7a8cc?cid=f114ad26-949d-44b4-87e9-8528afc76ce4

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
