### PR TITLE
Fix for #2459 - Tooltip Text Cut Off 

### DIFF
--- a/src/settings.html
+++ b/src/settings.html
@@ -17,7 +17,7 @@
     /*reduces size of tooltip for small desktop screens and above*/
     @media (min-width:992px) {
       .popover {
-        max-width: 120px;
+        width: 120px;
       }
     }
   </style>


### PR DESCRIPTION
## Description
Fix for https://github.com/Rise-Vision/rise-vision-apps/issues/2459 - Tooltip Text Cut Off 
Change width of the `popover` element

## Motivation and Context
Fix issue

## How Has This Been Tested?
Tested on local machine using proxy.
<img width="1117" alt="Screen Shot 2021-03-05 at 10 35 23 AM" src="https://user-images.githubusercontent.com/6841220/110137267-a7e46500-7d9e-11eb-80a3-9d21920d52b9.png">


## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
